### PR TITLE
blade create -t servicebuilder inside liferay-workspace doesn't create workspace build.gradle files

### DIFF
--- a/com.liferay.blade.cli/src/com/liferay/blade/cli/Util.java
+++ b/com.liferay.blade.cli/src/com/liferay/blade/cli/Util.java
@@ -91,11 +91,15 @@ public class Util {
 			return null;
 		}
 
-		for (String fileName : fileNames) {
-			File file = new File(dir, fileName);
+		for (int i = 0, j = 0; i < fileNames.length; i++) {
+			File file = new File(dir, fileNames[i]);
 
 			if (file.exists()) {
-				return dir;
+				j++;
+
+				if (j == fileNames.length) {
+					return dir;
+				}
 			}
 		}
 

--- a/com.liferay.blade.cli/test/com/liferay/blade/cli/CreateCommandTest.java
+++ b/com.liferay.blade.cli/test/com/liferay/blade/cli/CreateCommandTest.java
@@ -430,8 +430,8 @@ public class CreateCommandTest {
 
 		String projectPath = "generated/test/workspace/modules";
 
-		checkFileExists(
-			projectPath + "/workspace.sample/build.gradle");
+		lacks(checkFileExists(
+				projectPath + "/workspace.sample/build.gradle"), ".*repositories*\\s\\{.*");
 
 		checkFileExists(
 			projectPath + "/workspace.sample/com.sample.api/build.gradle");

--- a/com.liferay.blade.cli/test/com/liferay/blade/cli/CreateCommandTest.java
+++ b/com.liferay.blade.cli/test/com/liferay/blade/cli/CreateCommandTest.java
@@ -516,7 +516,12 @@ public class CreateCommandTest {
 
 		File settingsFile = new File(workspace, "settings.gradle");
 
+		String properties = "microsoft.translator.client.id=\nmicrosoft.translator.client.secret=";
+
+		File gradleProperties = new File(workspace, "gradle.properties");
+
 		Files.write(settingsFile.toPath(), settings.getBytes());
+		Files.write(gradleProperties.toPath(), properties.getBytes());
 	}
 
 }


### PR DESCRIPTION
This pull request fixed we can't create short build.gradle file when we create a servicebuilder project under the liferay workspace.