### PR TITLE
Change servicebuilder template's generated module names

### DIFF
--- a/com.liferay.blade.cli/src/com/liferay/blade/cli/CreateCommand.java
+++ b/com.liferay.blade.cli/src/com/liferay/blade/cli/CreateCommand.java
@@ -147,9 +147,9 @@ public class CreateCommand {
 				return;
 			}
 
-			subs.put("_api_", packageName + ".api");
-			subs.put("_svc_", packageName + ".svc");
-			subs.put("_web_", packageName + ".web");
+			subs.put("_api_", name + "-api");
+			subs.put("_svc_", name + "-service");
+			subs.put("_web_", name + "-web");
 			subs.put("_portlet_", packageName + ".portlet");
 			subs.put(
 				"_portletpackage_",

--- a/com.liferay.blade.cli/templates/standalone/servicebuilder/_svc_/build.gradle
+++ b/com.liferay.blade.cli/templates/standalone/servicebuilder/_svc_/build.gradle
@@ -11,13 +11,13 @@ dependencies {
 	compile 'biz.aQute.bnd:biz.aQute.bndlib:3.1.0'
 	compile 'com.liferay:com.liferay.portal.spring.extender:1.0.2'
 	compile 'com.liferay:com.liferay.osgi.util:2.0.4'
-	compile  project(':_package_.api')
+	compile  project(':_api_')
 	testCompile 'com.liferay:com.liferay.arquillian.extension.junit.bridge:1.0.0-SNAPSHOT'
 	testCompile 'junit:junit:4.+'
 }
 
 buildService {
-	apiDir = "../_package_.api/src/main/java"
+	apiDir = "../_api_/src/main/java"
 	osgiModule = true
 	propsUtil = "_package_.service.util.PropsUtil"
 	testDir = "src/main/test"

--- a/com.liferay.blade.cli/templates/standalone/servicebuilder/_web_/build.gradle
+++ b/com.liferay.blade.cli/templates/standalone/servicebuilder/_web_/build.gradle
@@ -3,6 +3,6 @@ dependencies {
 	compile 'javax.portlet:portlet-api:2.0'
 	compile 'javax.servlet:javax.servlet-api:3.0.1'
 	compile 'org.osgi:org.osgi.service.component.annotations:1.3.0'
-	compile  project(':_package_.api')
-	compile  project(':_package_.svc')
+	compile  project(':_api_')
+	compile  project(':_svc_')
 }

--- a/com.liferay.blade.cli/templates/workspace/servicebuilder/_svc_/build.gradle
+++ b/com.liferay.blade.cli/templates/workspace/servicebuilder/_svc_/build.gradle
@@ -11,13 +11,13 @@ dependencies {
 	compile 'biz.aQute.bnd:biz.aQute.bndlib:3.1.0'
 	compile 'com.liferay:com.liferay.portal.spring.extender:1.0.2'
 	compile 'com.liferay:com.liferay.osgi.util:2.0.4'
-	compile  project(':modules:_NAME_:_package_.api')
+	compile  project(':modules:_NAME_:_api_')
 	testCompile 'com.liferay:com.liferay.arquillian.extension.junit.bridge:1.0.0-SNAPSHOT'
 	testCompile 'junit:junit:4.+'
 }
 
 buildService {
-	apiDir = "../_package_.api/src/main/java"
+	apiDir = "../_api_/src/main/java"
 	osgiModule = true
 	propsUtil = "_package_.service.util.PropsUtil"
 	testDir = "src/main/test"

--- a/com.liferay.blade.cli/templates/workspace/servicebuilder/_web_/build.gradle
+++ b/com.liferay.blade.cli/templates/workspace/servicebuilder/_web_/build.gradle
@@ -3,6 +3,6 @@ dependencies {
 	compile 'javax.portlet:portlet-api:2.0'
 	compile 'javax.servlet:javax.servlet-api:3.0.1'
 	compile 'org.osgi:org.osgi.service.component.annotations:1.3.0'
-	compile  project(':modules:_NAME_:_package_.api')
-	compile  project(':modules:_NAME_:_package_.svc')
+	compile  project(':modules:_NAME_:_api_')
+	compile  project(':modules:_NAME_:_svc_')
 }


### PR DESCRIPTION
This PR updates the `servicebuilder` template and its generated module names. Previously, if you had the app name `test` and package name `com.liferay.docs`, it generated the following:

- `com.liferay.docs.api`
- `com.liferay.docs.svc`
- `com.liferay.docs.web`

With these updates, the module names are now the following:

- `test-api`
- `test-service`
- `test-web`

This naming scheme more directly follows the Liferay naming pattern for modules. It'll also make our tutorial explanations much easier :smiley: